### PR TITLE
feat(severity): make severity first-class across all issue kinds

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,28 @@
+## Steps to reproduce
+1. (fill in)
+2. (fill in)
+3. (fill in)
+
+## Expected
+(what should happen)
+
+## Actual
+(what actually happens — include screenshots, logs, error messages)
+
+## Services
+{{services}}
+
+## Severity
+{{severity}}
+
+## Related feature
+{{related_feature}}
+
+## Environment
+- Branch:
+- Commit:
+- OS / Browser:
+- User role:
+
+---
+_Managed by gh-pms. Bugs auto-skip Gate 3 (docs)._

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,18 @@
+## Objective
+{{objective}}
+
+## Scope
+- [ ] (file/area touched)
+- [ ] (file/area touched)
+
+## Risk
+(what could break? how is it mitigated?)
+
+## Services
+{{services}}
+
+## Tasks
+- [ ] (added during work)
+
+---
+_Managed by gh-pms._

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,22 @@
+## Objective
+{{objective}}
+
+## Services
+{{services}}
+
+## Acceptance criteria
+- [ ] (fill in)
+- [ ] (fill in)
+- [ ] (fill in)
+
+## Tasks
+- [ ] (added by sub-agents during work)
+
+## Depends on
+{{depends_on}}
+
+## Notes
+(architecture decisions, risks, trade-offs)
+
+---
+_Managed by gh-pms. Do not edit `## Tasks` or `## Depends on` sections manually — use `/gh-pms:gh-task` and breakdown skills._

--- a/.github/ISSUE_TEMPLATE/plan.md
+++ b/.github/ISSUE_TEMPLATE/plan.md
@@ -1,0 +1,25 @@
+## Objective
+{{objective}}
+
+## Services
+{{services}}
+
+## Why now
+(motivation, constraints, deadlines)
+
+## Success criteria
+- [ ] (top-level outcome 1)
+- [ ] (top-level outcome 2)
+- [ ] (top-level outcome 3)
+
+## Breakdown
+_(populated by `/gh-pms:gh-breakdown` — do not edit manually)_
+
+## Open questions
+- (anything to clarify with the user before breakdown)
+
+## Notes
+(risks, trade-offs, parallel work, sequencing decisions)
+
+---
+_Managed by gh-pms. Use `/gh-pms:gh-breakdown #{this_issue}` to create child feature sub-issues._

--- a/.github/ISSUE_TEMPLATE/prd.md
+++ b/.github/ISSUE_TEMPLATE/prd.md
@@ -1,0 +1,21 @@
+## Problem
+(what user pain or business need does this address?)
+
+## Solution
+(high-level approach)
+
+## Users
+(who is this for?)
+
+## Success metrics
+- (measurable)
+- (measurable)
+
+## Out of scope
+- (explicit non-goals)
+
+## Linked plans
+_(populated as plans are created)_
+
+---
+_Managed by gh-pms. PRDs are top-level — they have plans as children, plans have features as children._

--- a/.github/ISSUE_TEMPLATE/request.md
+++ b/.github/ISSUE_TEMPLATE/request.md
@@ -1,0 +1,17 @@
+## Summary
+{{summary}}
+
+## Context
+Captured while working on: {{context}}
+Originator: {{originator}}
+
+## Initial triage
+- Likely kind: feature | bug | chore | hotfix | (decide on triage)
+- Likely services: (svc:* labels)
+- Effort guess: small | medium | large
+
+## Notes
+(anything the user said while requesting)
+
+---
+_Managed by gh-pms. To act on this request: triage by re-labeling (`type:request` → `type:feature`/`type:bug`) and run `/gh-pms:gh-current` to start work._

--- a/.github/ISSUE_TEMPLATE/testcase.md
+++ b/.github/ISSUE_TEMPLATE/testcase.md
@@ -1,0 +1,28 @@
+## Parent feature
+{{parent_feature}}
+
+## Scenario
+{{objective}}
+
+## Preconditions
+- (state required before the test runs)
+
+## Steps
+1. (step 1)
+2. (step 2)
+3. (step 3)
+
+## Expected result
+(observable outcome that proves the feature works)
+
+## Test type
+- [ ] Unit
+- [ ] Integration
+- [ ] E2E
+- [ ] Manual
+
+## Services
+{{services}}
+
+---
+_Managed by gh-pms. Test cases auto-skip Gate 3 (docs)._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+gh-pms PR template.
+The Closes line is REQUIRED — the pre-pr-create hook blocks PR creation without it.
+-->
+
+Closes #_
+
+## Summary
+(1–3 sentences — what changed and why, not how)
+
+## Quality
+- [ ] Tests pass locally
+- [ ] No new console.error / println / panic / unwrap added
+- [ ] Lint / typecheck / format clean
+- [ ] No secrets or credentials committed
+- [ ] Backwards compat preserved (or breakage documented)
+
+## Checklist (file paths)
+- `path/to/file1.ext` — (what changed)
+- `path/to/file2.ext` — (what changed)
+
+## Verification
+(how a reviewer can verify this works — commands, URLs, screenshots, test names)
+
+## Risk
+(what could break? mitigations? rollback plan if any?)
+
+---
+_Managed by gh-pms. Do not remove the Closes line._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] — 2026-04-29
+
+### Added — Severity is first-class on every issue kind
+
+Severity (`critical | high | medium | low`) was bug-only in v0.3. v0.4 makes it a first-class dimension on **every** issue kind so a P0 feature blocking launch is meaningfully different from a polish item — that signal is no longer lost. Closes #2.
+
+- **Canonical scale in `workflows/default.yaml#severities`** — single source of truth (`default: medium` + four-value list with label + Project field mapping). All severity-aware skills reference this list, so per-repo severity scales become a config-only change.
+- **`gh-feature` skill** — accepts an optional `severity` input on every kind (not just hotfix). Defaults to `medium`. Applies both the `severity:*` label and (when a Project v2 board is attached) the `Severity` field. Hotfixes still default to `critical`.
+- **`gh-task` skill** — sub-issue tasks **inherit the parent feature's severity** by default; can be overridden when the task is meaningfully more or less urgent than its parent. Checkbox tasks inherit implicitly.
+- **`gh-bug` skill** — drops its private `critical | high | medium | low` definition; references the workflow file instead. Same defaults, same behavior, one source of truth.
+- **`gh-status` skill** — within each Status bucket on the dashboard, issues are sorted by severity (Critical → Low) so urgent items surface first regardless of kind. Legend added to the example output.
+- **Templates** — `feature.md`, `chore.md`, and `testcase.md` gain a `## Severity` section. `plan.md` and `prd.md` stay exempt (they aggregate child severities).
+- **`gh-pms-orchestrator` agent** — skill-routing table calls out `severity` as an optional input on the relevant skills, plus a paragraph noting severity is first-class across kinds.
+
+### Changed
+
+- **Plugin manifest** — `version: 0.3.0 → 0.4.0`.
+
+### Backwards compatibility
+
+- Existing issues without a `severity:*` label remain valid.
+- Skills called without `severity` get `medium` and are not blocked.
+- `gh-bug` consumers see no behavior change.
+- `gh-init bootstrap-labels` already creates the four severity labels; no re-bootstrapping needed.
+
 ## [0.3.0] — 2026-04-29
 
 ### Added — `gh-push` skill + branching policy

--- a/README.md
+++ b/README.md
@@ -18,13 +18,26 @@ Most teams use GitHub Issues as a dumb backlog. `gh-pms` adds the structure that
 
 Everything lives natively in GitHub. Open the Issues, Milestones, or Projects tab and you see exactly where the project is.
 
-## What's new in v0.3
+## What's new in v0.4
 
-The "every feature must end with a linked PR" rule is now baked into the lifecycle:
+Severity is now a first-class dimension on **every** issue kind, not just bugs. A P0 feature blocking a launch is meaningfully different from a polish item — that signal was previously lost. Closes #2.
 
-- **`gh-push` skill** ✨ — One command to commit, push, open PR with `Closes #N`, post Gate 4 self-review evidence, ask the user to approve, and `gh pr merge`. Mirrors the popular `/push` pattern but PR-aware and lifecycle-integrated. Supports `--message`, `--no-merge`, `--admin`, `--squash` / `--merge` / `--rebase`, `--dry`, `--force`.
+- **Canonical scale** — `workflows/default.yaml#severities` is now the single source of truth (`default: medium` + four values, each mapped to a `severity:*` label and a Project v2 `Severity` field option). Per-repo severity scales become a config-only change.
+- **`gh-feature`** ✨ — accepts an optional `severity` on every kind (not just hotfix). Applied as label + Project field. Hotfixes still default to `critical`.
+- **`gh-task`** — sub-issue tasks inherit the parent feature's severity by default; override when the task is meaningfully more or less urgent. Checkbox tasks inherit implicitly.
+- **`gh-bug`** — references the canonical scale instead of defining its own. Same defaults, no behavior change.
+- **`gh-status`** — within each Status bucket, issues are sorted Critical → Low so urgent items surface first regardless of kind.
+- **Templates** — `feature.md`, `chore.md`, `testcase.md` gain a `## Severity` section. `plan.md` / `prd.md` stay exempt (they aggregate child severities).
+
+Backwards compatible — existing issues without a `severity:*` label remain valid, and skills called without `severity` get `medium`.
+
+### From v0.3: `gh-push` skill + branching policy
+
+The "every feature must end with a linked PR" rule is baked into the lifecycle:
+
+- **`gh-push` skill** — One command to commit, push, open PR with `Closes #N`, post Gate 4 self-review evidence, ask the user to approve, and `gh pr merge`. Mirrors the popular `/push` pattern but PR-aware and lifecycle-integrated. Supports `--message`, `--no-merge`, `--admin`, `--squash` / `--merge` / `--rebase`, `--dry`, `--force`.
 - **Branching policy** — `workflows/default.yaml#branching` defines `protected_base` (default: `main` / `master`), `pr_required_kinds` (feature / bug / hotfix / chore / testcase), `branch_template` (default: `{kind_short}/{number}-{slug}`), and `pr_must_close_issue: true`. The rule is enforced in three places: `gh-current` auto-creates the branch on start, `gh-advance` Gate 1 refuses if HEAD is on the protected base, and `gh-push` refuses to ship from the protected base.
-- **`gh-current`** now records `branch` + `base` in the per-issue state file so `gh-push` finds them later. The "🚧 Work started" comment mentions the branch name.
+- **`gh-current`** records `branch` + `base` in the per-issue state file so `gh-push` finds them later. The "🚧 Work started" comment mentions the branch name.
 - **`gh-advance`** Gate 1 has a clear rescue-recipe error if work is on the wrong branch. One-off legacy state can opt out with the `[gh-pms: branch-exception]` marker in the issue body.
 
 ### From v0.2: GitHub-native primitives
@@ -80,6 +93,10 @@ Examples:
   → /gh-pms:gh-current sets Status: In Progress
   → work happens, gates open, PR opens with Closes #N
   → user approves, PR merges, issue auto-closes
+
+"Build the launch-blocking SSO refresh — this is P0"
+  → /gh-pms:gh-feature with severity: critical
+  → severity:critical label + Severity = Critical on the project board
 
 "The login page redirects to 404 after 2FA"
   → /gh-pms:gh-bug creates issue, sets Issue Type "Bug", severity:medium
@@ -188,12 +205,13 @@ Milestones   (always): one per plan, with optional due date + auto-progress
 
 ## Configuration
 
-Per-repo overrides in `.github/gh-pms.yaml` (planned for v0.3):
+The plugin's defaults live in [`plugins/gh-pms/workflows/default.yaml`](plugins/gh-pms/workflows/default.yaml). The `severities` block is already structured for per-repo overrides — extend or replace its `values` list and the severity-aware skills (`gh-feature`, `gh-bug`, `gh-task`, `gh-status`) pick up the new scale automatically.
+
+Per-repo overrides in `.github/gh-pms.yaml` (planned):
 
 - Custom workflow definitions
 - Disable/enable specific gates
 - Custom service labels
-- Custom severity scale
 - Map custom Issue Types beyond the GitHub default set
 
 ## License

--- a/plugins/gh-pms/.claude-plugin/plugin.json
+++ b/plugins/gh-pms/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.claude.com/claude-code/plugin.json",
   "name": "gh-pms",
   "description": "GitHub Issues as a project-management system — plans, features, bugs, evidence-gated lifecycle, PR-driven review. Mirrors Orchestra MCP / Studio PMS workflow but stores everything natively on GitHub.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Fady Mondy",
     "email": "info@3x1.io",

--- a/plugins/gh-pms/agents/gh-pms-orchestrator.md
+++ b/plugins/gh-pms/agents/gh-pms-orchestrator.md
@@ -46,9 +46,10 @@ You inherit the proven workflow shape of Orchestra MCP and Studio PMS, but every
 | User signal | Skill |
 |---|---|
 | "plan X" / 3+ features | `/gh-pms:gh-plan` then `/gh-pms:gh-breakdown` |
-| "build X" / "add Y" / "implement Z" (single feature) | `/gh-pms:gh-feature` |
-| "fix bug" / "X is broken" | `/gh-pms:gh-bug` |
-| "refactor" / "clean up" / "ci" / "deps" | `/gh-pms:gh-feature` with kind=chore |
+| "build X" / "add Y" / "implement Z" (single feature) | `/gh-pms:gh-feature` (optional `severity`) |
+| "fix bug" / "X is broken" | `/gh-pms:gh-bug` (optional `severity`) |
+| "refactor" / "clean up" / "ci" / "deps" | `/gh-pms:gh-feature` with kind=chore (optional `severity`) |
+| "track sub-step under #N" | `/gh-pms:gh-task` (inherits parent severity; optional override) |
 | "let's start work on #N" / "begin #N" | `/gh-pms:gh-current` (auto-creates the feature branch) |
 | "tests pass" / "advance #N" | `/gh-pms:gh-advance` |
 | "ship #N" / "push #N" / "open PR for #N" / "/push" | `/gh-pms:gh-push` (commit + push + PR + Gates 4/5) |
@@ -57,6 +58,8 @@ You inherit the proven workflow shape of Orchestra MCP and Studio PMS, but every
 | "status" / "where are we" | `/gh-pms:gh-status` |
 | "would this evidence pass?" | `/gh-pms:gh-validate` |
 | Repo not bootstrapped (labels missing) | `/gh-pms:gh-init` first |
+
+**Severity is a first-class dimension on every issue kind**, not just bugs. The full scale (`critical | high | medium | low`) lives in `workflows/default.yaml.severities` and defaults to `medium` when omitted. Pass `severity` to `gh-feature`, `gh-bug`, or `gh-task` whenever priority is non-default — features blocking a launch, chores with security exposure, etc.
 
 ## Hard rules (fail loudly if violated)
 

--- a/plugins/gh-pms/skills/gh-bug/SKILL.md
+++ b/plugins/gh-pms/skills/gh-bug/SKILL.md
@@ -25,7 +25,7 @@ Required:
 
 Optional:
 - `services` — `svc:*` labels
-- `severity` — critical | high | medium | low (default `medium`)
+- `severity` — resolved against `workflows/default.yaml.severities.values[]`. Defaults to that file's `severities.default` (`medium` out of the box). Same scale used by `gh-feature` and `gh-task` — bugs no longer own a private severity definition.
 - `related_feature` — original feature issue number if regression
 
 ### Step 2 — Detect features

--- a/plugins/gh-pms/skills/gh-feature/SKILL.md
+++ b/plugins/gh-pms/skills/gh-feature/SKILL.md
@@ -26,7 +26,7 @@ Optional:
 - `services` — `svc:*` labels
 - `parent_feature` — required if `kind=testcase`
 - `milestone` — milestone title or number to attach to (if working under a plan)
-- `severity` — for hotfixes only
+- `severity` — `critical | high | medium | low` (default: `medium`, per `workflows/default.yaml.severities.default`). Applies to every kind — a P0 feature blocking launch is meaningfully different from a polish item. Hotfixes default to `critical`. Resolved against `workflows/default.yaml.severities.values[]` so per-repo scales work.
 
 ### Step 2 — Resolve issue type (if available)
 
@@ -50,8 +50,8 @@ Map `kind` → GitHub type via `workflows/default.yaml.kind_to_issue_type`:
 
 Use `mcp__github__issue_write`:
 - `title`: `[{Kind}] {title}`
-- `body`: filled `templates/{kind}.md`
-- `labels`: always include `type:{kind}` (even when issue type is set, for at-a-glance filtering), `status:todo`, plus `svc:*`. Add `priority:critical` for hotfix.
+- `body`: filled `templates/{kind}.md` (set `## Severity` to the resolved severity name)
+- `labels`: always include `type:{kind}` (even when issue type is set, for at-a-glance filtering), `status:todo`, `severity:{severity}`, plus `svc:*`. Add `priority:critical` for hotfix.
 - `assignees`: `[me]` if user said "I'll do this", otherwise omit
 
 Capture the new issue number `N`.
@@ -79,8 +79,9 @@ If a `gh-pms` project exists:
 ```bash
 PN=$(...)  # from gh project list
 ITEM_ID=$(${CLAUDE_PLUGIN_ROOT}/lib/ghcall.sh project-item-add "{owner}" "$PN" "https://github.com/{owner}/{repo}/issues/{N}")
-${CLAUDE_PLUGIN_ROOT}/lib/ghcall.sh project-item-set-field "{owner}" "$PN" "$ITEM_ID" "Status" "Todo"
-${CLAUDE_PLUGIN_ROOT}/lib/ghcall.sh project-item-set-field "{owner}" "$PN" "$ITEM_ID" "Service" "{primary_service}"
+${CLAUDE_PLUGIN_ROOT}/lib/ghcall.sh project-item-set-field "{owner}" "$PN" "$ITEM_ID" "Status"   "Todo"
+${CLAUDE_PLUGIN_ROOT}/lib/ghcall.sh project-item-set-field "{owner}" "$PN" "$ITEM_ID" "Severity" "{Severity}"   # title-cased project value, e.g. "Medium"
+${CLAUDE_PLUGIN_ROOT}/lib/ghcall.sh project-item-set-field "{owner}" "$PN" "$ITEM_ID" "Service"  "{primary_service}"
 ```
 
 ### Step 7 — Sub-issue link (if testcase)
@@ -96,6 +97,7 @@ mcp__github__sub_issue_write — link {N} as sub-issue of {parent_feature}
 {Kind} #{N} created: {title}
   Issue Type:  {Feature/Bug/Task or "label fallback: type:{kind}"}
   Status:      Todo (project field {if project} + status:todo label)
+  Severity:    {severity}
   Milestone:   {title or "—"}
   Labels:      {labels list}
   URL:         https://github.com/{owner}/{repo}/issues/{N}

--- a/plugins/gh-pms/skills/gh-status/SKILL.md
+++ b/plugins/gh-pms/skills/gh-status/SKILL.md
@@ -15,9 +15,10 @@ Project-management dashboard for the current repo.
    ```bash
    gh project item-list <project_number> --owner <owner> --format json
    ```
-   Group by Project's `Status` field.
+   Group by Project's `Status` field. **Within each Status bucket, sort by `Severity` (Critical → High → Medium → Low)** so the most urgent items surface first regardless of kind. Severity values come from `workflows/default.yaml.severities.values[]`.
 4. **Otherwise** (no project), fall back to label-based grouping:
    - `mcp__github__list_issues` — all open issues, grouped by `status:*` label
+   - Within each group, sort by `severity:*` label using the same Critical → Low order
    - Issues assigned to current user with `status:in-progress`
    - Open `type:request` issues
 5. **Always** include milestone progress via `gh api repos/{owner}/{repo}/milestones?state=open` — show plans (= milestones) with their progress bars
@@ -29,16 +30,17 @@ gh-pms · {owner}/{repo}                    [Project: gh-pms (#3)] [Issue Types:
 Active (assigned to @{me})
   #43 [Feature] Bridge endpoint        Status: In Progress    Effort: M  started 2h ago
 
-Pipeline (from Project Status field)
-  Todo                : 5  (#44 #45 #46 #47 #48)
-  In Progress         : 1  (#43)
+Pipeline (from Project Status field, severity-sorted)
+  Todo                : 5  (#44🔴 #45🟠 #46🟡 #47🟡 #48🟢)
+  In Progress         : 1  (#43🟠)
   Ready for Testing   : 0
   In Testing          : 0
   Ready for Docs      : 0
   In Docs             : 0
   Documented          : 0
-  In Review           : 2  (#41 #42)
-  Blocked             : 1  (#39 — blocked by #38)
+  In Review           : 2  (#41🔴 #42🟡)
+  Blocked             : 1  (#39🟠 — blocked by #38)
+  Legend: 🔴 critical · 🟠 high · 🟡 medium · 🟢 low
 
 Milestones (= Plans)
   #M1 Migrate auth flow            ████░░░░░ 60%   3/5 closed   due 2026-06-01

--- a/plugins/gh-pms/skills/gh-task/SKILL.md
+++ b/plugins/gh-pms/skills/gh-task/SKILL.md
@@ -20,17 +20,28 @@ Add a task to an existing feature.
 | < 30 min, no separate verification needed | Checkbox in parent feature body |
 | ≥ 30 min OR has its own evidence | Real sub-issue with `type:chore` or `type:feature` (kind decided by user) |
 
+## Inputs
+
+Required:
+- `parent` — feature issue number the task hangs off
+- `description` — what the task is
+
+Optional:
+- `severity` — `critical | high | medium | low`. Defaults to **the parent feature's severity** (read the parent's `severity:*` label, or its Project v2 `Severity` field if a project is attached). Override only when the task is meaningfully more or less urgent than its parent. Resolved against `workflows/default.yaml.severities.values[]`.
+- `kind` — `chore` or `feature`, defaults to `chore` for sub-issue path.
+
 ## What it does — sub-issue path
 
-1. Same flow as `/gh-pms:gh-feature` with kind=chore (or kind specified)
-2. Calls `mcp__github__sub_issue_write` to link as sub-issue of parent feature
-3. Reports child issue number
+1. Resolve severity: use the explicit `severity` if provided, else read the parent's `severity:*` label (or Project v2 `Severity` field), else fall back to `workflows/default.yaml.severities.default`.
+2. Same flow as `/gh-pms:gh-feature` with kind=chore (or kind specified) — pass the resolved severity through.
+3. Calls `mcp__github__sub_issue_write` to link as sub-issue of parent feature.
+4. Reports child issue number and the resolved severity (note whether it was inherited or overridden).
 
 ## What it does — checkbox path
 
 1. Reads parent feature body via `mcp__github__get_file_contents` (or `issue_read`)
 2. Locates the `## Tasks` section (creates if missing)
-3. Appends `- [ ] {task description}`
+3. Appends `- [ ] {task description}` (severity is implicit — checkboxes inherit the parent's severity, no annotation needed)
 4. Updates issue via `mcp__github__issue_write` with `update_issue` action
 5. Reports: `Added task to #N: {description}`
 

--- a/plugins/gh-pms/templates/chore.md
+++ b/plugins/gh-pms/templates/chore.md
@@ -11,6 +11,9 @@
 ## Services
 {{services}}
 
+## Severity
+{{severity}}
+
 ## Tasks
 - [ ] (added during work)
 

--- a/plugins/gh-pms/templates/feature.md
+++ b/plugins/gh-pms/templates/feature.md
@@ -4,6 +4,9 @@
 ## Services
 {{services}}
 
+## Severity
+{{severity}}
+
 ## Acceptance criteria
 - [ ] (fill in)
 - [ ] (fill in)

--- a/plugins/gh-pms/templates/testcase.md
+++ b/plugins/gh-pms/templates/testcase.md
@@ -24,5 +24,8 @@
 ## Services
 {{services}}
 
+## Severity
+{{severity}}
+
 ---
 _Managed by gh-pms. Test cases auto-skip Gate 3 (docs)._

--- a/plugins/gh-pms/workflows/default.yaml
+++ b/plugins/gh-pms/workflows/default.yaml
@@ -100,6 +100,32 @@ gates:
     required_user_approval: true
     description: "User approves via AskUserQuestion. PR merge auto-closes the issue."
 
+# Severity scale — canonical source of truth for the `severity:*` label set
+# and the Project v2 `Severity` field. Applies to ALL issue kinds, not just
+# bugs (a P0 feature blocking launch is meaningfully different from a polish
+# item). Skills accept an optional `severity` input; default is `medium`.
+# Per-repo overrides are allowed — extend or replace the list to fit your
+# scale, but keep `default` pointing to a value present in the list.
+severities:
+  default: medium
+  values:
+    - name: critical
+      label: severity:critical
+      project_field_value: Critical
+      description: P0 — drop everything
+    - name: high
+      label: severity:high
+      project_field_value: High
+      description: P1 — fix this sprint
+    - name: medium
+      label: severity:medium
+      project_field_value: Medium
+      description: P2 — schedule
+    - name: low
+      label: severity:low
+      project_field_value: Low
+      description: P3 — nice to have
+
 # Programmatic guardrails
 guardrails:
   wip_limit: 1


### PR DESCRIPTION
Closes #2

## Summary
Severity was previously bug-only. This PR extends it to features, chores, and testcases so a P0 feature blocking a launch can be distinguished from a polish item — that signal was previously lost.

## Changes
- **`workflows/default.yaml`** — new canonical `severities` section (with `default: medium` and the four-value scale). All severity-aware skills now reference this list, so per-repo severity scales work without skill edits.
- **`skills/gh-feature/SKILL.md`** — `severity` is now an optional input for every kind (not just hotfix). Defaults to `medium`. Applied as both the `severity:*` label and Project v2 `Severity` field.
- **`skills/gh-task/SKILL.md`** — adds an Inputs section. Sub-issue tasks **inherit the parent feature's severity** by default; can be overridden.
- **`skills/gh-bug/SKILL.md`** — drops the ad-hoc `critical | high | medium | low (default medium)` definition; references the workflow instead.
- **`skills/gh-status/SKILL.md`** — within each Status bucket, issues are sorted Critical → Low; legend added to the example dashboard.
- **`templates/{feature,chore,testcase}.md`** — gain a `## Severity` section. `plan.md` and `prd.md` are intentionally exempt (they aggregate child severities).
- **`agents/gh-pms-orchestrator.md`** — skill table calls out `severity` as an optional input on the relevant skills, plus a one-paragraph note that severity is first-class across kinds.

## Backwards compatibility
- Existing issues without a `severity:*` label remain valid.
- Skills called without `severity` get `medium` and are not blocked.
- Existing `gh-bug` consumers see no behavior change — the same defaults apply.
- `gh-init bootstrap-labels` already creates the four severity labels (no change needed).

## Out of scope (intentionally, per issue notes)
- Severity-based gate cooldowns
- Severity-driven WIP rules
- Custom per-repo severity scales beyond the existing four (the new YAML structure makes this a config-only change later)

## Test plan
- [ ] `gh-feature` with `severity: critical` creates an issue with the `severity:critical` label and (if Project v2 attached) the `Severity = Critical` field
- [ ] `gh-feature` without `severity` creates an issue with `severity:medium`
- [ ] `gh-task` sub-issue inherits parent severity when not overridden
- [ ] `gh-task` sub-issue uses the override when provided
- [ ] `gh-bug` continues to work with the same defaults (no regression)
- [ ] `gh-status` shows issues ordered by severity within each Status bucket
- [ ] Template-generated issue bodies render the `## Severity` section