### PR TITLE
feat(config): per-repo overrides via .github/gh-pms.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,14 +217,23 @@ Milestones   (always): one per plan, with optional due date + auto-progress
 
 ## Configuration
 
-The plugin's defaults live in [`plugins/gh-pms/workflows/default.yaml`](plugins/gh-pms/workflows/default.yaml). The `severities` block is already structured for per-repo overrides — extend or replace its `values` list and the severity-aware skills (`gh-feature`, `gh-bug`, `gh-task`, `gh-status`) pick up the new scale automatically.
+The plugin's defaults live in [`plugins/gh-pms/workflows/default.yaml`](plugins/gh-pms/workflows/default.yaml). To override per repo, drop a `.github/gh-pms.yaml` in the repo (an annotated example lives at [`plugins/gh-pms/templates/gh-pms.yaml.example`](plugins/gh-pms/templates/gh-pms.yaml.example) — `gh-init --customize` copies it for you).
 
-Per-repo overrides in `.github/gh-pms.yaml` (planned):
+The merge is shallow at the top-level key: any section you set in your override **replaces** its default counterpart wholesale. To extend a list, copy the defaults into your override and add yours.
 
-- Custom workflow definitions
-- Disable/enable specific gates
-- Custom service labels
-- Map custom Issue Types beyond the GitHub default set
+Inspect the merged result anytime:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/lib/load-config.sh 0 | jq .
+```
+
+Common overrides:
+
+- **Severity scale** — replace the `severities` block to use blocker/high/medium/nit instead of the default critical/high/medium/low
+- **Service taxonomy** — swap `github_features.project_fields[Service].options` to your team's repo set; `gh-init bootstrap-labels` creates the matching `svc:*` labels automatically
+- **Gate evidence** — add or remove required sections per gate (e.g. add a `Threat model` section to Gate 1 for security-sensitive repos)
+- **Branching policy** — change `protected_base` or `branch_template` to fit non-`main` defaults
+- **Custom kinds** — add a new issue kind beyond feature/bug/hotfix/chore/testcase/plan/prd/request
 
 ## License
 

--- a/plugins/gh-pms/lib/ghcall.sh
+++ b/plugins/gh-pms/lib/ghcall.sh
@@ -79,19 +79,63 @@ bootstrap_labels() {
   ensure_label "status:blocked"            "CF222E" "Halted by external dependency"
   ensure_label "status:done"               "1A7F37" "Merged + verified"
 
-  # Severity (used by bugs)
-  ensure_label "severity:critical"  "B60205" "P0 — drop everything"
-  ensure_label "severity:high"      "D93F0B" "P1 — fix this sprint"
-  ensure_label "severity:medium"    "FBCA04" "P2 — schedule"
-  ensure_label "severity:low"       "0E8A16" "P3 — nice to fix"
+  # Severity — read from merged config when available so per-repo
+  # severity scales create the right labels. Falls back to the canonical
+  # four if load-config.sh is unavailable (yq missing, etc.).
+  local plugin_root="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+  local loader="${plugin_root}/lib/load-config.sh"
+  local cfg=""
+  if [[ -x "$loader" ]] && cfg=$("$loader" 0 2>/dev/null) && [[ -n "$cfg" ]]; then
+    echo "$cfg" | jq -r '.severities.values[] | [.label, .description] | @tsv' \
+      | while IFS=$'\t' read -r label desc; do
+        [[ -n "$label" ]] || continue
+        # Color tier by position in the list (deterministic)
+        local color="FBCA04"
+        case "$label" in
+          *critical*|*blocker*|*p0*) color="B60205" ;;
+          *high*|*p1*)               color="D93F0B" ;;
+          *medium*|*p2*)             color="FBCA04" ;;
+          *low*|*nit*|*p3*)          color="0E8A16" ;;
+        esac
+        ensure_label "$label" "$color" "$desc"
+      done
+  else
+    ensure_label "severity:critical"  "B60205" "P0 — drop everything"
+    ensure_label "severity:high"      "D93F0B" "P1 — fix this sprint"
+    ensure_label "severity:medium"    "FBCA04" "P2 — schedule"
+    ensure_label "severity:low"       "0E8A16" "P3 — nice to fix"
+  fi
 
+  # Service taxonomy — also read from merged config when present
   if [[ "${SKIP_SERVICES:-0}" != "1" ]]; then
-    ensure_label "svc:app"      "C5DEF5" "Frontend / app code"
-    ensure_label "svc:bridge"   "C5DEF5" "Backend / API"
-    ensure_label "svc:studio"   "C5DEF5" "Studio / admin"
-    ensure_label "svc:edge"     "C5DEF5" "Edge functions"
-    ensure_label "svc:db"       "C5DEF5" "Database / migrations"
-    ensure_label "svc:devops"   "C5DEF5" "CI / deploy / infra"
+    if [[ -n "$cfg" ]]; then
+      local svc_options
+      svc_options=$(echo "$cfg" | jq -r '
+        (.github_features.project_fields // [])
+        | map(select(.name == "Service"))
+        | first.options // []
+        | .[]')
+      if [[ -n "$svc_options" ]]; then
+        while IFS= read -r svc; do
+          [[ -n "$svc" ]] || continue
+          ensure_label "svc:${svc}" "C5DEF5" "Service: ${svc}"
+        done <<< "$svc_options"
+      else
+        ensure_label "svc:app"      "C5DEF5" "Frontend / app code"
+        ensure_label "svc:bridge"   "C5DEF5" "Backend / API"
+        ensure_label "svc:studio"   "C5DEF5" "Studio / admin"
+        ensure_label "svc:edge"     "C5DEF5" "Edge functions"
+        ensure_label "svc:db"       "C5DEF5" "Database / migrations"
+        ensure_label "svc:devops"   "C5DEF5" "CI / deploy / infra"
+      fi
+    else
+      ensure_label "svc:app"      "C5DEF5" "Frontend / app code"
+      ensure_label "svc:bridge"   "C5DEF5" "Backend / API"
+      ensure_label "svc:studio"   "C5DEF5" "Studio / admin"
+      ensure_label "svc:edge"     "C5DEF5" "Edge functions"
+      ensure_label "svc:db"       "C5DEF5" "Database / migrations"
+      ensure_label "svc:devops"   "C5DEF5" "CI / deploy / infra"
+    fi
   fi
   echo "Done."
 }

--- a/plugins/gh-pms/lib/load-config.sh
+++ b/plugins/gh-pms/lib/load-config.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# gh-pms · load-config.sh
+# Merge the plugin's default workflow with the per-repo override (if any).
+# Output: a single JSON document on stdout. Callers parse with jq.
+#
+# Resolution order (later wins, shallow merge per top-level key):
+#   1. plugins/gh-pms/workflows/default.yaml          (always)
+#   2. .github/gh-pms.yaml in the active repo         (if present)
+#   3. GH_PMS_CONFIG env var pointing to a YAML file  (if set; for tests)
+#
+# Per-repo overrides are shallow at the top-level key. Whole sections
+# (severities, github_features, gates, etc.) replace their default
+# equivalents when present in the override file. Lists are not merged
+# element-wise — a partial `severities.values` override replaces the
+# whole list. This keeps semantics predictable; if you want to extend,
+# copy the default values into your override and add yours.
+#
+# Requires: yq (mikefarah/yq v4+), jq.
+
+set -euo pipefail
+
+CACHE_TTL_DEFAULT=60
+CACHE_TTL="${1:-$CACHE_TTL_DEFAULT}"
+
+DEFAULT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}/workflows/default.yaml"
+OVERRIDE_REPO=""
+OVERRIDE_ENV="${GH_PMS_CONFIG:-}"
+
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  REPO_ROOT=$(git rev-parse --show-toplevel)
+  if [[ -f "$REPO_ROOT/.github/gh-pms.yaml" ]]; then
+    OVERRIDE_REPO="$REPO_ROOT/.github/gh-pms.yaml"
+  fi
+fi
+
+# ---------- preflight --------------------------------------------------------
+
+command -v yq >/dev/null 2>&1 \
+  || { echo "load-config: yq not found. Install via 'brew install yq'." >&2; exit 127; }
+command -v jq >/dev/null 2>&1 \
+  || { echo "load-config: jq not found." >&2; exit 127; }
+[[ -f "$DEFAULT" ]] \
+  || { echo "load-config: default workflow missing at $DEFAULT" >&2; exit 1; }
+
+# ---------- cache lookup -----------------------------------------------------
+
+CACHE_DIR="${HOME}/.cache/gh-pms"
+mkdir -p "$CACHE_DIR"
+
+# Cache key incorporates the override paths + their mtimes (so edits invalidate)
+key_input="$DEFAULT"
+[[ -n "$OVERRIDE_REPO" ]] && key_input+=":$(stat -f %m "$OVERRIDE_REPO" 2>/dev/null || stat -c %Y "$OVERRIDE_REPO")"
+[[ -n "$OVERRIDE_ENV"  ]] && key_input+=":$(stat -f %m "$OVERRIDE_ENV"  2>/dev/null || stat -c %Y "$OVERRIDE_ENV")"
+key=$(echo "$key_input" | shasum 2>/dev/null | awk '{print $1}' || echo "no-sha")
+CACHE_FILE="${CACHE_DIR}/config-${key}.json"
+
+if (( CACHE_TTL > 0 )) && [[ -f "$CACHE_FILE" ]]; then
+  age=$(( $(date +%s) - $(stat -f %m "$CACHE_FILE" 2>/dev/null || stat -c %Y "$CACHE_FILE") ))
+  if (( age < CACHE_TTL )); then
+    cat "$CACHE_FILE"
+    exit 0
+  fi
+fi
+
+# ---------- merge ------------------------------------------------------------
+
+# Convert each YAML to JSON, then jq-merge top-level keys (shallow merge).
+default_json=$(yq -o=json '.' "$DEFAULT")
+merged="$default_json"
+
+if [[ -n "$OVERRIDE_REPO" ]]; then
+  override_json=$(yq -o=json '.' "$OVERRIDE_REPO")
+  merged=$(jq -n --argjson a "$merged" --argjson b "$override_json" '$a * $b')
+fi
+
+if [[ -n "$OVERRIDE_ENV" && -f "$OVERRIDE_ENV" ]]; then
+  override_json=$(yq -o=json '.' "$OVERRIDE_ENV")
+  merged=$(jq -n --argjson a "$merged" --argjson b "$override_json" '$a * $b')
+fi
+
+# ---------- emit + cache -----------------------------------------------------
+
+echo "$merged" > "$CACHE_FILE"
+echo "$merged"

--- a/plugins/gh-pms/skills/gh-init/SKILL.md
+++ b/plugins/gh-pms/skills/gh-init/SKILL.md
@@ -92,7 +92,23 @@ Copy from this plugin's `templates/` to the active repo's `.github/`:
 
 If a target already exists, ASK before overwriting.
 
-## Step 7 — Commit templates
+## Step 7 — (optional) Drop in a per-repo config skeleton
+
+If the user passed `--customize` (or said "I want to override severities/services/gates"):
+
+```bash
+cp "${CLAUDE_PLUGIN_ROOT}/templates/gh-pms.yaml.example" .github/gh-pms.yaml
+```
+
+The example is fully commented — every section is opt-in. Skipping `--customize` is fine for teams running with the canonical defaults; the loader gracefully falls back when no override file exists.
+
+Verify the merged result anytime:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/lib/load-config.sh" 0 | jq .
+```
+
+## Step 8 — Commit templates
 
 ```bash
 git add .github/
@@ -101,7 +117,7 @@ git commit -m "chore: bootstrap gh-pms templates and labels"
 
 Do NOT add Co-Authored-By trailers. Use the user's git config.
 
-## Step 8 — Report
+## Step 9 — Report
 
 ```
 gh-pms ready in {owner}/{repo}
@@ -109,7 +125,8 @@ gh-pms ready in {owner}/{repo}
     Issue Types:  ✓ Feature / Bug / Task (org-level)         [or ✗ falling back to type:* labels]
     Projects v2:  ✓ "gh-pms" project #{N} with 4 fields      [or ✗ skipped]
     Milestones:   ✓ enabled
-  Labels: 26 created (8 type, 10 status, 4 severity, 4 service)
+  Labels: 28 created (8 type, 10 status, 4 severity, 6 service)   [counts reflect the merged config]
+  Per-repo config: .github/gh-pms.yaml         [or ✗ skipped]
   Templates: 7 issue templates + PR template added
   Committed: chore: bootstrap gh-pms templates and labels
 Next: /gh-pms:gh-feature, /gh-pms:gh-bug, /gh-pms:gh-plan

--- a/plugins/gh-pms/templates/gh-pms.yaml.example
+++ b/plugins/gh-pms/templates/gh-pms.yaml.example
@@ -1,0 +1,89 @@
+# gh-pms · per-repo override
+#
+# This file overrides values from the plugin's default workflow
+# (plugins/gh-pms/workflows/default.yaml). Top-level keys you set here
+# REPLACE their default counterpart wholesale — there is no element-wise
+# merge for lists. To extend a list, copy the defaults into this file
+# and add your additions.
+#
+# Drop this file at .github/gh-pms.yaml in your repo. The loader picks
+# it up automatically. Run `lib/load-config.sh 0 | jq` to inspect the
+# merged result.
+#
+# Everything in this file is OPTIONAL — delete the sections you don't
+# need. The defaults already cover most teams.
+
+# ─── Severity scale ──────────────────────────────────────────────────
+# Override the default critical/high/medium/low scale. The `default`
+# value MUST appear in `values`. Each value's `label` and
+# `project_field_value` map to the GitHub label and Project v2 Severity
+# field option respectively.
+#
+# severities:
+#   default: medium
+#   values:
+#     - name: blocker
+#       label: severity:blocker
+#       project_field_value: Blocker
+#       description: P0 — production down
+#     - name: high
+#       label: severity:high
+#       project_field_value: High
+#       description: P1 — fix this sprint
+#     - name: medium
+#       label: severity:medium
+#       project_field_value: Medium
+#       description: P2 — schedule
+#     - name: nit
+#       label: severity:nit
+#       project_field_value: Low
+#       description: cosmetic / polish
+
+# ─── Service taxonomy ────────────────────────────────────────────────
+# Override the default app/bridge/studio/edge/db/devops services. Each
+# becomes an `svc:*` label on `gh-init` bootstrap. Project v2's Service
+# field options also follow this list when the loader is integrated
+# with the Projects field provisioning.
+#
+# github_features:
+#   project_fields:
+#     - { name: "Service", type: "single_select", options: ["api", "web", "ios", "android", "infra"] }
+
+# ─── Custom kinds ────────────────────────────────────────────────────
+# Add a new issue kind beyond the default set (feature/bug/hotfix/chore/
+# testcase/plan/prd/request). Each new kind needs a `kind_to_issue_type`
+# mapping (or null if it shouldn't have a native type).
+#
+# kinds:
+#   - name: experiment
+#     description: Time-boxed validation; auto-closes after 2 weeks
+#     parent: null
+#
+# kind_to_issue_type:
+#   experiment: "Task"
+
+# ─── Gate evidence overrides ─────────────────────────────────────────
+# Replace required sections per gate. Useful for security-sensitive
+# repos that want a "Threat model" section in Gate 1, or compliance
+# repos that need an "Audit trail" section in Gate 4.
+#
+# gates:
+#   - id: gate1
+#     from: in-progress
+#     to: ready-for-testing
+#     skip_for_kinds: []
+#     required_sections:
+#       - { name: Summary,      min_chars: 10 }
+#       - { name: Changes,      min_chars: 10, require_file_paths: true }
+#       - { name: Verification, min_chars: 10 }
+#       - { name: Threat model, min_chars: 30 }   # added requirement
+#     description: "Code complete + threat model documented."
+
+# ─── Branching policy overrides ──────────────────────────────────────
+# Tweak the protected base branches, kinds that require a PR, or the
+# branch naming template.
+#
+# branching:
+#   protected_base: [main, develop]
+#   pr_required_kinds: [feature, bug, hotfix, chore]
+#   branch_template: "{kind_short}/issue-{number}-{slug}"


### PR DESCRIPTION
Closes #6

## Summary
Drops the long-promised per-repo override. Teams can now drop `.github/gh-pms.yaml` in their repo and the loader shallow-merges it over the canonical `workflows/default.yaml`. Without it, customizing the severity scale or service taxonomy meant forking the plugin.

## Changes
- **`lib/load-config.sh`** — yq+jq merger. Resolution order: `workflows/default.yaml` < `.github/gh-pms.yaml` < `GH_PMS_CONFIG` env var (for tests). Output: a single merged JSON document on stdout. Caches in `~/.cache/gh-pms/config-<sha>.json` keyed by mtimes so edits invalidate automatically.
- **`lib/ghcall.sh bootstrap-labels`** — reads the merged severities and service list, creates matching `severity:*` and `svc:*` labels. Color tier picked deterministically from label name (critical/blocker → red, high → orange, medium → yellow, low/nit → green). Falls back to the canonical four+six when the loader isn't available (yq missing).
- **`templates/gh-pms.yaml.example`** — fully annotated, every section opt-in. Covers severities, service taxonomy, custom kinds, gate evidence overrides, branching policy.
- **`skills/gh-init/SKILL.md`** — adds Step 7 "drop in a per-repo skeleton with `--customize`", renumbers downstream Steps.
- **`README.md`** — Configuration section rewritten with override schema, common use cases, and the `load-config.sh` inspection command.

## Verification
Loader merging an override file:
```bash
$ GH_PMS_CONFIG=/tmp/test-override.yaml lib/load-config.sh 0 \
  | jq '{sevs: .severities.values | map(.label),
         svc: (.github_features.project_fields | map(select(.name=="Service")) | first.options)}'
{
  "sevs": ["severity:blocker", "severity:high", "severity:medium", "severity:nit"],
  "svc":  ["api", "web", "mobile"]
}
```

Default behavior (no override):
```bash
$ lib/load-config.sh 0 | jq '.severities.default, (.statuses | length)'
"medium"
10
```

## Backwards compatibility
- Repos without `.github/gh-pms.yaml` see the exact same behavior as before
- `yq` is an optional dep — `bootstrap-labels` falls back to the canonical set if missing
- Existing `severity:*` and `svc:*` labels are not deleted; only missing ones are added

## Out of scope (intentionally, per issue notes)
- Per-repo overrides for the gates evidence sections feed through to `lib/validate-evidence.sh` — covered by issue #18 "per-kind gate sections" which extends the same loader
- AI-driven config validation: not needed for v1; the schema is small enough to read

## Test plan
- [ ] Run `lib/load-config.sh 0 | jq` in this repo (no override) — confirm canonical defaults
- [ ] Drop a `.github/gh-pms.yaml` with a custom severity, run again — confirm override applied
- [ ] Run `lib/ghcall.sh bootstrap-labels` with an override file — confirm matching labels created
- [ ] Delete `yq` from PATH temporarily — confirm `bootstrap-labels` falls back gracefully