### PR TITLE
feat(gate4): refuse review-ready when PR checks are red

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Milestones   (always): one per plan, with optional due date + auto-progress
 - **Kind-specific skips** — Bugs/hotfixes/testcases skip Gate 3 (docs)
 - **Branching policy** (v0.3) — Feature work must land on a feature branch, not on `main` / `master`. `gh-current` auto-creates the branch; `gh-advance` Gate 1 refuses from the protected base; `gh-push` refuses to ship from the protected base. Bootstrap commits with no issue number are exempt.
 - **PR enforcement** — Every feature must end with a PR containing `Closes #N` so merge auto-closes the issue. Gate 4 requires it; `gh-push` injects it automatically.
+- **CI gate on Gate 4** (v0.5+) — `documented → in-review` refuses if any required PR check is failing or still pending. `lib/check-pr-checks.sh` is the source of truth. Override only with `--ignore-checks "<reason>"`, which records the reason in a `## Check overrides` section of the evidence comment for audit.
 - **User-only Gate 5** — Only `gh-push` Step 5 (or `gh-review`'s Phase 2) can move to `done`, and only after `AskUserQuestion` approval
 - **Native primitives preferred** — Issue Types, Project Status field, and Milestones are used when available; labels stay as a fallback and visible-at-a-glance signal
 

--- a/plugins/gh-pms/agents/gh-pms-orchestrator.md
+++ b/plugins/gh-pms/agents/gh-pms-orchestrator.md
@@ -68,6 +68,7 @@ You inherit the proven workflow shape of Orchestra MCP and Studio PMS, but every
 - **Never start work** on an issue you haven't `gh-current`-ed
 - **Never commit feature work directly to a `protected_base` branch** (default: main / master). `gh-current` creates the branch; `gh-advance` Gate 1 and `gh-push` both refuse work that ignored this. The only exemptions are pure bootstrapping commits with no issue number.
 - **Every feature must end with a linked PR** containing `Closes #N` so merge auto-closes the issue. `gh-push` enforces this.
+- **Gate 4 refuses red CI**. If any required PR check is failing or still pending, Gate 4 (`documented → in-review`) refuses. `lib/check-pr-checks.sh` is the source of truth. Override only with `--ignore-checks "<reason>"`, which records the reason in the evidence comment.
 - **Never advance to `done`** via `gh-advance` — only `gh-push` Step 5 (or `gh-review`'s Phase 2) with explicit user approval
 - **Never bypass gates** by editing labels directly — always go through the skill so cooldown + state file update
 - **Never assume a label exists** — if `gh-init` hasn't run, run it first

--- a/plugins/gh-pms/lib/check-pr-checks.sh
+++ b/plugins/gh-pms/lib/check-pr-checks.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# gh-pms · check-pr-checks.sh
+# Verify that a PR's required checks are passing. Exits 0 if all green
+# (or skipped/neutral), 1 with a human-readable failure list otherwise.
+#
+# Usage:
+#   check-pr-checks.sh <pr-number-or-url>
+#
+# Output (exit 1):
+#   gh-pms: Gate 4 refuses — failing checks on PR #<N>:
+#     ✗ <check-name>     <conclusion>     <details_url>
+#   To override (records the reason in the gate evidence comment):
+#     gh-advance --ignore-checks "explanation"
+
+set -euo pipefail
+
+PR="${1:?usage: check-pr-checks.sh <pr-number-or-url>}"
+
+command -v gh >/dev/null 2>&1 || { echo "check-pr-checks: gh required" >&2; exit 127; }
+command -v jq >/dev/null 2>&1 || { echo "check-pr-checks: jq required" >&2; exit 127; }
+
+CHECKS=$(gh pr view "$PR" --json statusCheckRollup -q '.statusCheckRollup' 2>/dev/null || echo "[]")
+[[ -n "$CHECKS" && "$CHECKS" != "null" ]] || CHECKS="[]"
+
+FAILING=$(echo "$CHECKS" | jq -r '
+  [ .[]
+    | select(.__typename == "CheckRun" and .status == "COMPLETED")
+    | select(.conclusion != "SUCCESS" and .conclusion != "SKIPPED" and .conclusion != "NEUTRAL")
+  ]')
+
+PENDING=$(echo "$CHECKS" | jq -r '
+  [ .[]
+    | select(.__typename == "CheckRun" and .status != "COMPLETED")
+  ]')
+
+FAIL_COUNT=$(echo "$FAILING" | jq 'length')
+PEND_COUNT=$(echo "$PENDING" | jq 'length')
+
+if (( FAIL_COUNT == 0 && PEND_COUNT == 0 )); then
+  exit 0
+fi
+
+echo "gh-pms: Gate 4 refuses — PR #${PR} checks not all green"
+if (( FAIL_COUNT > 0 )); then
+  echo "  Failing:"
+  echo "$FAILING" | jq -r '.[] | "    ✗ \(.name)\t\(.conclusion // "?")\t\(.detailsUrl // "")"' | column -ts $'\t'
+fi
+if (( PEND_COUNT > 0 )); then
+  echo "  Pending (not yet finished):"
+  echo "$PENDING" | jq -r '.[] | "    … \(.name)\t\(.status)\t\(.detailsUrl // "")"' | column -ts $'\t'
+  echo "  Wait for these to finish, then re-run."
+fi
+echo
+echo "To override (records the reason in the gate evidence comment):"
+echo "  gh-advance #N --ignore-checks \"<short reason — e.g. 'flaky linter, see thread'>\""
+exit 1

--- a/plugins/gh-pms/skills/gh-advance/SKILL.md
+++ b/plugins/gh-pms/skills/gh-advance/SKILL.md
@@ -70,7 +70,13 @@ Move an issue forward through its lifecycle, enforcing the gate.
         Evidence: {comment_url}
         Next: {next-action-hint}
         ```
-8. **For Gate 4 (documented → in-review)**: must verify a PR is open with `Closes #{N}` in body. Use `mcp__github__list_pull_requests` to find any PR mentioning the issue number. If no PR exists, route the user to `/gh-pms:gh-push #{N}` which handles push + PR creation + review-request in one shot.
+8. **For Gate 4 (documented → in-review)**: must verify a PR is open with `Closes #{N}` in body. Use `mcp__github__list_pull_requests` to find any PR mentioning the issue number. If no PR exists, route the user to `/gh-pms:gh-push #{N}` which handles push + PR creation + review-request in one shot. Then run the CI check:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/lib/check-pr-checks.sh <PR-number>
+   ```
+   - Exit 0 → Gate 4 proceeds.
+   - Exit 1 → REFUSE the transition. The script prints which checks are failing/pending and the override hint.
+   - **Override**: if the user passes `--ignore-checks "<reason>"`, skip the refusal **but** append a `## Check overrides` section to the gate evidence comment with the reason. This is for cases like "flaky linter, will fix in follow-up #123" — the audit trail is the point. Don't let it become a habit; the cooldown won't help here.
 9. **For Gate 5 (in-review → done)**: this skill REJECTS direct calls. User must approve via `/gh-pms:gh-review`'s `submit_review` step. Return:
    ```
    Cannot advance to status:done directly. Use /gh-pms:gh-review to request user approval, then submit the decision.

--- a/plugins/gh-pms/skills/gh-push/SKILL.md
+++ b/plugins/gh-pms/skills/gh-push/SKILL.md
@@ -130,9 +130,10 @@ If the issue's current status is `documented`:
    - {…}
    ```
 2. Validate via `lib/validate-evidence.sh` (or a manual section-length + file-existence check on macOS bash 3 — see `gh-advance` notes).
-3. Post the comment via `gh issue comment {N} --body-file ...`.
-4. Flip status: `${CLAUDE_PLUGIN_ROOT}/lib/ghcall.sh set-status {N} "In Review"`.
-5. Update the state file (`last_transition_at`, `current_status: in-review`).
+3. **CI gate** — run `${CLAUDE_PLUGIN_ROOT}/lib/check-pr-checks.sh <PR>`. Refuse Gate 4 if exit code is non-zero (failing or still-pending checks). The script prints the failure list and the override hint. Override path: `--ignore-checks "<reason>"` skips the refusal but appends a `## Check overrides` section to the evidence comment with the reason. Use sparingly — the override is an audit trail, not a free pass.
+4. Post the comment via `gh issue comment {N} --body-file ...`.
+5. Flip status: `${CLAUDE_PLUGIN_ROOT}/lib/ghcall.sh set-status {N} "In Review"`.
+6. Update the state file (`last_transition_at`, `current_status: in-review`).
 
 If the issue is **not yet** at `documented` (e.g. user is shipping mid-flight), STOP after Step 3 and tell them:
 ```

--- a/plugins/gh-pms/workflows/default.yaml
+++ b/plugins/gh-pms/workflows/default.yaml
@@ -92,6 +92,8 @@ gates:
         require_file_paths: true
     description: "Self-review before user approval. Summary, quality notes, file checklist."
     requires_pr: true
+    requires_passing_checks: true   # refuse the transition if any required PR check is failing
+    check_override_section: "Check overrides"   # if --ignore-checks is used, the reason is recorded here
 
   - id: gate5
     from: in-review


### PR DESCRIPTION
Closes #7

## Summary
Gate 4 was honor-system on CI. v0.5 makes 'checks must be passing' a hard requirement with an explicit override path.

## Changes
- `workflows/default.yaml` gate4 — `requires_passing_checks: true` + `check_override_section`
- `lib/check-pr-checks.sh` — exits 1 with the failing-check list when any required check is failing/pending
- `skills/gh-advance/SKILL.md` + `skills/gh-push/SKILL.md` — invoke the script in their Gate 4 step; document `--ignore-checks "<reason>"`
- `agents/gh-pms-orchestrator.md` — adds hard rule
- `README.md` — surfaces the new guardrail

## Backwards compatibility
PRs with no checks pass through (empty rollup → exit 0). Repos can override the gate4 block in `.github/gh-pms.yaml` (per #6) to revert to honor-system if they want.

## Test plan
- [ ] Run on a PR with green checks — exits 0
- [ ] Run on a PR with a failing check — exits 1 with the failing-check name and the override hint
- [ ] Run on a PR with pending checks — exits 1 with 'Wait for these to finish' message