### PR TITLE
feat(gh-triage): drain the type:request inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Milestones   (always): one per plan, with optional due date + auto-progress
 | `/gh-pms:gh-status`       | `pms_list_features` (reads project board)     |
 | `/gh-pms:gh-context` ✨   | (new in v0.5) — session-start summary         |
 | `/gh-pms:gh-release` ✨   | (new in v0.5) — version bump + tag + release  |
+| `/gh-pms:gh-triage` ✨    | (new in v0.5) — drain the type:request inbox  |
 
 ## Hooks
 

--- a/plugins/gh-pms/agents/gh-pms-orchestrator.md
+++ b/plugins/gh-pms/agents/gh-pms-orchestrator.md
@@ -55,6 +55,7 @@ You inherit the proven workflow shape of Orchestra MCP and Studio PMS, but every
 | "ship #N" / "push #N" / "open PR for #N" / "/push" | `/gh-pms:gh-push` (commit + push + PR + Gates 4/5) |
 | "request review" / "ready for review" (no merge yet) | `/gh-pms:gh-review` |
 | Mid-flow new ask | `/gh-pms:gh-request` |
+| "drain the inbox" / "triage requests" | `/gh-pms:gh-triage` (loops the type:request queue with accept/reject/defer) |
 | "status" / "where are we" | `/gh-pms:gh-status` |
 | "what was I doing" / new session warmup | `/gh-pms:gh-context` (auto-runs via `SessionStart` hook) |
 | "ship vX.Y" / "cut a release" / "bump version" | `/gh-pms:gh-release` (changelog + plugin.json + tag + GitHub release) |

--- a/plugins/gh-pms/skills/gh-triage/SKILL.md
+++ b/plugins/gh-pms/skills/gh-triage/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: gh-triage
+description: Drain the `type:request` inbox — for each deferred user ask, decide accept-as-feature / accept-as-bug / reject / defer-again. Promotes accepted requests into real work; closes rejected ones with a documented reason. Auto-invoke when the user says "triage requests", "drain the inbox", "what's in the request queue".
+---
+
+# gh-triage
+
+Walk the `type:request` queue and convert each item into a decision: real work, rejected, or punt for later. Closes the loop on `gh-request`'s deferred captures.
+
+## When to use
+
+- User says "triage requests", "drain the inbox", "review the queue"
+- The request count in `gh-context` / `gh-status` is creeping up
+- Pre-planning: before cutting a milestone, drain the requests so anything urgent gets folded in
+
+## What it does
+
+### Step 1 — List the queue
+
+```bash
+gh issue list --repo {owner}/{repo} --label type:request --state open --limit 100 \
+  --json number,title,body,createdAt,labels,assignees \
+  --jq 'sort_by(.createdAt)'
+```
+
+Oldest first — the longer something has sat unpromoted, the higher the priority on triage.
+
+If the queue is empty, report `No requests to triage. ✓` and exit.
+
+### Step 2 — For each item, ask the user
+
+Use `AskUserQuestion` with four options. Title shown is the request body's first line, plus the days-since-filed:
+
+```
+Request #{N}: "{first line of body}"
+Filed {days} days ago by @{author}.
+
+  [a] Accept as feature → run /gh-pms:gh-feature with this body as objective
+  [b] Accept as bug     → run /gh-pms:gh-bug with this body as steps_to_reproduce
+  [r] Reject             → close with reason (you'll be asked for the reason)
+  [d] Defer again        → leave it; increment a `Deferred` counter in the body
+```
+
+### Step 3a — Accept as feature
+
+1. Call `/gh-pms:gh-feature` with:
+   - `title` = request title (strip `[Request]` prefix if present)
+   - `objective` = request body
+   - `kind` = `feature` (or `chore` if the user picked that variant)
+   - Severity inherited from the request's `severity:*` label if set, else default
+2. Capture the new issue number `M`
+3. On the original request `#N`:
+   - Post a comment: `🔁 Promoted to #${M} (feature)`
+   - Close as `completed` with reason "Promoted to issue #${M}"
+4. Report: `✓ #${N} → #${M} (feature)`
+
+### Step 3b — Accept as bug
+
+Same as 3a but call `/gh-pms:gh-bug`. The request body becomes the bug's `## Actual` section; ask the user for a 1-line `## Expected` if the body doesn't already have one.
+
+### Step 3c — Reject
+
+1. `AskUserQuestion`: "Why are you rejecting #${N}? (free-text reason)"
+2. Append a `## Rejection reason` section to the request body (or update if exists)
+3. Post a comment: `❌ Rejected: ${reason}`
+4. Close as `not_planned` (`gh issue close ${N} --reason "not planned"`)
+5. Report: `✗ #${N} rejected — ${reason}`
+
+### Step 3d — Defer again
+
+1. Read the request body. Find a `## Deferred` section; if missing, add one with `1`. If present, increment.
+2. Update the body via `mcp__github__issue_write` (`update_issue`).
+3. Post a one-line comment: `⏸  Deferred #${N} (count: ${new_count})`. If count crosses 3, also tag with `severity:low` to surface the staleness next triage round.
+4. Report: `… #${N} deferred (now ${new_count})`
+
+### Step 4 — Repeat or stop
+
+If the user passed `--all`, jump back to Step 2 with the next item until the queue is empty or the user picks "stop".
+
+Otherwise, after one item: ask "Continue with next request? [yes/no/stop]" and loop or exit accordingly.
+
+### Step 5 — Final summary
+
+```
+Triage session done.
+  Accepted as feature : 2  (#42 #43)
+  Accepted as bug     : 1  (#44)
+  Rejected            : 3  (#21 #22 #23)
+  Deferred again      : 1  (#19)
+  Skipped (still open): 0
+```
+
+## Notes
+
+- **Idempotent**: re-running on an already-empty queue is a no-op.
+- **No bulk-accept**: each request gets a deliberate decision. Bulk-reject is supported via `--all` because the user keeps clicking "Reject", but there's no single-keystroke "reject everything" — that would defeat the purpose.
+- The original request issue is **closed** when accepted (not deleted) so the audit trail stays. Cross-references (`#${M} promoted from #${N}`) appear in both timelines.
+
+## Cross-skill contract
+
+- Pairs with `/gh-pms:gh-request` (which files them) and `/gh-pms:gh-context` (which surfaces the count). Triage is the closing of the loop.
+- A request with `severity:critical` should ideally never sit in the queue more than 24h — `gh-status` could flag it; `gh-triage` doesn't enforce, only reports.


### PR DESCRIPTION
Closes #8

## Summary
The type:request queue was a write-only graveyard — gh-request filed them, nothing converted them back into work. gh-triage walks the queue with explicit decisions per item.

## Behavior
- Lists open type:request issues oldest-first
- For each: AskUserQuestion with 4 options (accept-as-feature, accept-as-bug, reject, defer-again)
- Accept → calls gh-feature/gh-bug, posts cross-reference comment on the original, closes as completed with promotion link
- Reject → asks for reason, appends to body, closes as not_planned
- Defer-again → increments a counter; if it crosses 3, tags severity:low for staleness surfacing
- --all bulk-walks the queue until empty or user stops
- Final summary tallies decisions

## Test plan
- [ ] Empty queue: reports 'No requests to triage. ✓' and exits
- [ ] Single accept → confirm new feature issue created with cross-reference and source closed
- [ ] Single reject → confirm reason recorded in body and issue closed not_planned
- [ ] Defer 4 times on same issue → confirm severity:low applied